### PR TITLE
fix: edit job permissions to enable actions to open PRs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
To open PRs the workflow needed 
```
permissions: 
  pull-requests: write
```