### PR TITLE
fix: emberfall exits with code 0 even on failing tests

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -17,6 +17,10 @@ jobs:
     name: Analysis
     uses: ./.github/workflows/analysis.yaml
 
+  tests:
+    name: Tests
+    uses: ./.github/workflows/tests.yaml
+
   release:
     name: Release
     needs: analysis

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -19,6 +19,7 @@ jobs:
 
   tests:
     name: Tests
+    needs: analysis
     uses: ./.github/workflows/tests.yaml
 
   release:

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -24,7 +24,9 @@ jobs:
 
   release:
     name: Release
-    needs: analysis
+    needs: 
+      - analysis
+      - tests
     if: startsWith(github.ref, 'refs/tags/v')
     uses: ./.github/workflows/release.yaml
     secrets: inherit

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  workflow_call:
+
+jobs:
+  Lint-Go:
+    name: Lint Go
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+      
+      - uses: actions/setup-go@v5
+
+      - name: Compile
+        run: go build -o ./ ./...
+
+      - id: setup-bats
+        uses: bats-core/bats-action@3.0.0
+
+      - name: Test CLI
+        shell: bash
+        env:
+          BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
+          TERM: xterm
+        run: bats tests/cli.bats

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,8 +4,8 @@ on:
   workflow_call:
 
 jobs:
-  Lint-Go:
-    name: Lint Go
+  tests:
+    name: BATS cli
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Tests are defined in a simple YAML document that defines the following keys:
 tests:
 - url: string
   method: string #a supported HTTP method such as GET, POST, PUT, DELETE, etc...
+  follow: bool # optional, whether to follow redirects or not, defaults to false
   expect:
     status: int #a supported HTTP status code such as 200,201,301,400,404, etc...
     body: string # optional

--- a/internal/engine/config.go
+++ b/internal/engine/config.go
@@ -10,8 +10,7 @@ import (
 )
 
 type config struct {
-	Run   string  `json:"run"`
-	Tests []*test `json:"tests"`
+	Tests []*test `yaml:"tests"`
 }
 
 func LoadConfig(configPath string) (*config, error) {
@@ -46,5 +45,6 @@ func LoadConfig(configPath string) (*config, error) {
 
 	conf := &config{}
 	err = yaml.Unmarshal(b, conf)
+
 	return conf, err
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -7,9 +7,10 @@ import (
 
 func Run(cfg *config) {
 	var (
-		req *http.Request
-		res *http.Response
-		err error
+		client *http.Client = &http.Client{}
+		req    *http.Request
+		res    *http.Response
+		err    error
 	)
 
 	for _, test := range cfg.Tests {
@@ -25,7 +26,13 @@ func Run(cfg *config) {
 			req.Header.Set(k, v)
 		}
 
-		res, err = http.DefaultClient.Do(req)
+		if test.FollowRedirect {
+			client.CheckRedirect = nil
+		} else {
+			client.CheckRedirect = noRedirect
+		}
+
+		res, err = client.Do(req)
 		if err != nil {
 			fmt.Println(err)
 			continue
@@ -33,4 +40,8 @@ func Run(cfg *config) {
 
 		test.report(res)
 	}
+}
+
+func noRedirect(req *http.Request, via []*http.Request) error {
+	return http.ErrUseLastResponse
 }

--- a/internal/engine/test.go
+++ b/internal/engine/test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 )
 
@@ -55,5 +56,10 @@ func (t *test) report(res *http.Response) {
 		for _, e := range errors {
 			fmt.Printf("  %s\n", e)
 		}
+		code := len(errors)
+		if code > 125 {
+			code = 125
+		}
+		os.Exit(code)
 	}
 }

--- a/internal/engine/test.go
+++ b/internal/engine/test.go
@@ -9,13 +9,14 @@ import (
 )
 
 type test struct {
-	Url     string            `json:"url"`
-	Method  string            `json:"method"`
-	Headers map[string]string `json:"headers"`
-	Expect  struct {
-		Status  int               `json:"status"`
-		Body    *string           `json:"body,omitempty"`
-		Headers map[string]string `json:"headers,omitempty"`
+	Url            string            `yaml:"url"`
+	Method         string            `yaml:"method"`
+	Headers        map[string]string `yaml:"headers"`
+	FollowRedirect bool              `yaml:"follow"`
+	Expect         struct {
+		Status  int               `yaml:"status"`
+		Body    *string           `yaml:"body,omitempty"`
+		Headers map[string]string `yaml:"headers,omitempty"`
 	}
 }
 
@@ -24,14 +25,14 @@ func (t *test) report(res *http.Response) {
 	result := "PASS"
 
 	if t.Expect.Status != res.StatusCode {
-		errors = append(errors, fmt.Sprintf("expected %d got %d", t.Expect.Status, res.StatusCode))
+		errors = append(errors, fmt.Sprintf("expected status == %d got %d", t.Expect.Status, res.StatusCode))
 	}
 
 	if t.Expect.Body != nil {
 		b, _ := io.ReadAll(res.Body)
 		bs := strings.TrimSpace(string(b))
 		if *t.Expect.Body != bs {
-			errors = append(errors, fmt.Sprintf("expected body %s != %s", *t.Expect.Body, bs))
+			errors = append(errors, fmt.Sprintf("expected body == %s got %s", *t.Expect.Body, bs))
 		}
 	}
 
@@ -42,7 +43,7 @@ func (t *test) report(res *http.Response) {
 			if !ok {
 				errors = append(errors, fmt.Sprintf("expected header %s was missing", expectedHeader))
 			} else if expectedValue != value {
-				errors = append(errors, fmt.Sprintf("expected header %s:%v != %v", expectedHeader, expectedValue, value))
+				errors = append(errors, fmt.Sprintf("expected header %s:%v got %v", expectedHeader, expectedValue, value))
 			}
 		}
 	}
@@ -51,7 +52,7 @@ func (t *test) report(res *http.Response) {
 		result = "FAIL"
 	}
 
-	fmt.Printf("%s : %s\n", result, t.Url)
+	fmt.Printf("%s : %s %s\n", result, t.Method, t.Url)
 	if len(errors) > 0 {
 		for _, e := range errors {
 			fmt.Printf("  %s\n", e)

--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -4,7 +4,36 @@ setup() {
     bats_load_library bats-assert
 }
 
-@test "emberfall with no config SHOULD FAIL" {
+@test "no config SHOULD FAIL" {
     run ./emberfall
     assert_failure
+    assert_output --partial 'no config provided'
 }
+
+@test "SHOULD FAIL without following redirect" {
+  run ./emberfall --config ./tests/fail-no-follow.yml
+  assert_failure
+  assert_output --partial 'FAIL'
+  assert_output --partial 'expected status == 200 got 301'
+}
+
+@test "SHOULD PASS by following redirect" {
+  run ./emberfall --config ./tests/pass-follow.yml
+  assert_success
+  assert_output --partial 'PASS'
+}
+
+@test "SHOULD PASS with expected headers" {
+  run ./emberfall --config ./tests/pass-headers.yml
+  assert_success
+  assert_output --partial 'PASS'
+}
+
+
+@test "SHOULD FAIL with missing headers" {
+  run ./emberfall --config ./tests/pass-missing-headers.yml
+  assert_failure
+  assert_output --partial 'FAIL'
+  assert_output --partial 'expected header x-no-exist was missing'
+}
+

--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -1,3 +1,11 @@
+_tests_helper() {
+    export BATS_LIB_PATH=${BATS_LIB_PATH:-"/usr/lib"}
+    bats_load_library bats-support
+    bats_load_library bats-assert
+    bats_load_library bats-file
+    bats_load_library bats-detik/detik.bash
+}
+
 @test "emberfall with no config" {
     run ./emberfall
     assert_failure

--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -1,12 +1,10 @@
-_tests_helper() {
+setup() {
     export BATS_LIB_PATH=${BATS_LIB_PATH:-"/usr/lib"}
     bats_load_library bats-support
     bats_load_library bats-assert
-    bats_load_library bats-file
-    bats_load_library bats-detik/detik.bash
 }
 
-@test "emberfall with no config" {
+@test "emberfall with no config SHOULD FAIL" {
     run ./emberfall
     assert_failure
 }

--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -1,0 +1,4 @@
+@test "emberfall with no config" {
+    run ./emberfall
+    assert_failure
+}

--- a/tests/fail-no-follow.yml
+++ b/tests/fail-no-follow.yml
@@ -1,0 +1,5 @@
+tests:
+  - url: https://google.com
+    method: GET
+    expect:
+      status: 200 # should fail with != 301

--- a/tests/pass-follow.yml
+++ b/tests/pass-follow.yml
@@ -1,0 +1,6 @@
+tests:
+  - url: https://google.com
+    method: GET
+    follow: true
+    expect:
+      status: 200 # should pass by following redirect

--- a/tests/pass-headers.yml
+++ b/tests/pass-headers.yml
@@ -1,0 +1,8 @@
+tests:
+  - url: https://www.google.com
+    method: GET
+    expect:
+      status: 200 
+      headers:
+        content-type: "text/html; charset=ISO-8859-1"
+        server: "gws"

--- a/tests/pass-missing-headers.yml
+++ b/tests/pass-missing-headers.yml
@@ -1,0 +1,9 @@
+tests:
+  - url: https://www.google.com
+    method: GET
+    expect:
+      status: 200 
+      headers:
+        content-type: "text/html; charset=ISO-8859-1"
+        server: "gws"
+        x-no-exist: "should be missing"


### PR DESCRIPTION
## Added

.github/workflows/tests workflow which sets up and executes [BATS](https://github.com/bats-core/bats-action)
tests/cli.bats which defines BATS tests to run against the CLI binary

## Changed
- .github/workflows/pipeline to enable the new tests workflow
- internal/engine/
  - exit non zero when tests contain errors
  - convert struct tags from json to yaml
  - added follow redirect flag as bool
  - using http.Client instead of DefaultClient


closes #13 