### PR TITLE
feat: support request and expects body as json or plain text

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -16,11 +16,14 @@ func Run(cfg *config) (success bool) {
 		failures int
 	)
 
+	// TODO: refactor this loop into Tests.run() by making config.Tests type Tests as []*test
 	for _, test := range cfg.Tests {
 		var (
 			err error
 			b   []byte
 		)
+
+		test.bootstrap()
 
 		buf := new(bytes.Buffer)
 
@@ -35,10 +38,17 @@ func Run(cfg *config) (success bool) {
 				test.addError(err)
 				continue
 			}
+
+			if _, ok := test.Headers["Content-Type"]; !ok {
+				test.Headers["Content-Type"] = "application/json"
+			}
 		}
 
 		if test.ReqBody.Text != nil {
 			b = []byte(*test.ReqBody.Text)
+			if _, ok := test.Headers["Content-Type"]; !ok {
+				test.Headers["Content-Type"] = "text/plain"
+			}
 		}
 
 		buf = bytes.NewBuffer(b)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1,6 +1,9 @@
 package engine
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 )
@@ -10,16 +13,45 @@ func Run(cfg *config) (success bool) {
 		client   *http.Client = &http.Client{}
 		req      *http.Request
 		res      *http.Response
-		err      error
 		failures int
 	)
 
 	for _, test := range cfg.Tests {
+		var (
+			err error
+			b   []byte
+		)
 
-		req, err = http.NewRequest(test.Method, test.Url, nil)
+		buf := new(bytes.Buffer)
+
+		if test.ReqBody.Json != nil && test.ReqBody.Text != nil {
+			test.addError(errors.New("may define body.json or body.text but not both"))
+			continue
+		}
+
+		if test.ReqBody.Json != nil {
+			b, err = json.Marshal(test.ReqBody.Json)
+			if err != nil {
+				test.addError(err)
+				continue
+			}
+		}
+
+		if test.ReqBody.Text != nil {
+			b = []byte(*test.ReqBody.Text)
+		}
+
+		buf = bytes.NewBuffer(b)
+
+		req, err = http.NewRequest(test.Method, test.Url, buf)
 
 		if err != nil {
-			fmt.Println(err)
+			test.addError(err)
+		}
+
+		// exit early if test already has errors
+		if len(test.errors) > 0 {
+			test.report()
 			failures++
 			continue
 		}
@@ -41,7 +73,7 @@ func Run(cfg *config) (success bool) {
 			continue
 		}
 
-		if !test.report(res) {
+		if !test.validate(res) {
 			failures++
 		}
 	}
@@ -50,7 +82,7 @@ func Run(cfg *config) (success bool) {
 		success = true
 	}
 
-	fmt.Printf("\n Ran %d tests with %d failures\n", len(cfg.Tests), failures)
+	fmt.Printf("\nRan %d tests with %d failures\n", len(cfg.Tests), failures)
 	return
 }
 

--- a/internal/engine/test.go
+++ b/internal/engine/test.go
@@ -34,6 +34,12 @@ type test struct {
 	pass   bool
 }
 
+func (t *test) bootstrap() {
+	if t.Headers == nil {
+		t.Headers = map[string]string{}
+	}
+}
+
 func (t *test) validate(res *http.Response) bool {
 	var err error
 

--- a/internal/engine/test.go
+++ b/internal/engine/test.go
@@ -1,41 +1,69 @@
 package engine
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 )
 
+var result = map[bool]string{
+	true:  "PASS",
+	false: "FAIL",
+}
+
+type body struct {
+	Json map[string]interface{} `yaml:"json,omitempty"`
+	Text *string                `yaml:"text,omitempty"`
+}
+
 type test struct {
 	Url            string            `yaml:"url"`
 	Method         string            `yaml:"method"`
 	Headers        map[string]string `yaml:"headers"`
 	FollowRedirect bool              `yaml:"follow"`
+	ReqBody        body              `yaml:"body"`
 	Expect         struct {
-		Status  int               `yaml:"status"`
-		Body    *string           `yaml:"body,omitempty"`
+		Status  *int              `yaml:"status,omitempty"`
+		ResBody *body             `yaml:"body,omitempty"`
 		Headers map[string]string `yaml:"headers,omitempty"`
 	}
+	errors []error
+	pass   bool
 }
 
-func (t *test) report(res *http.Response) (success bool) {
-	errors := []string{}
+func (t *test) validate(res *http.Response) bool {
+	var err error
 
-	result := map[bool]string{
-		true:  "PASS",
-		false: "FAIL",
+	if t.Expect.Status != nil {
+		if *t.Expect.Status != res.StatusCode {
+			t.addError(fmt.Errorf("expected status == %d got %d", *t.Expect.Status, res.StatusCode))
+		}
 	}
 
-	if t.Expect.Status != res.StatusCode {
-		errors = append(errors, fmt.Sprintf("expected status == %d got %d", t.Expect.Status, res.StatusCode))
-	}
+	if t.Expect.ResBody != nil {
+		bodyBytes, _ := io.ReadAll(res.Body)
 
-	if t.Expect.Body != nil {
-		b, _ := io.ReadAll(res.Body)
-		bs := strings.TrimSpace(string(b))
-		if *t.Expect.Body != bs {
-			errors = append(errors, fmt.Sprintf("expected body == %s got %s", *t.Expect.Body, bs))
+		if t.Expect.ResBody.Text != nil && t.Expect.ResBody.Json != nil {
+			t.addError(errors.New("may expect body.text or body.json but not both"))
+		} else if t.Expect.ResBody.Text != nil {
+			bs := strings.TrimSpace(string(bodyBytes))
+
+			if *t.Expect.ResBody.Text != bs {
+				t.addError(fmt.Errorf("expected body.text == %s got %s", *t.Expect.ResBody.Text, bs))
+			}
+		} else if t.Expect.ResBody.Json != nil {
+			var resJson map[string]interface{}
+			err = json.Unmarshal(bodyBytes, &resJson)
+
+			if err != nil {
+				t.addError(err)
+			} else {
+				// compare returned json to expect.body.json recursively
+				t.compare("body.json", t.Expect.ResBody.Json, resJson)
+			}
 		}
 	}
 
@@ -44,23 +72,50 @@ func (t *test) report(res *http.Response) (success bool) {
 			v, ok := res.Header[http.CanonicalHeaderKey(expectedHeader)]
 			value := strings.Join(v, "")
 			if !ok {
-				errors = append(errors, fmt.Sprintf("expected header %s was missing", expectedHeader))
+				t.addError(fmt.Errorf("expected header %s was missing", expectedHeader))
 			} else if expectedValue != value {
-				errors = append(errors, fmt.Sprintf("expected header %s:%v got %v", expectedHeader, expectedValue, value))
+				t.addError(fmt.Errorf("expected header %s:%v got %v", expectedHeader, expectedValue, value))
 			}
 		}
 	}
 
-	if len(errors) == 0 {
-		success = true
+	if len(t.errors) == 0 {
+		t.pass = true
 	}
 
-	fmt.Printf("%s : %s %s\n", result[success], t.Method, t.Url)
-	if len(errors) > 0 {
-		for _, e := range errors {
+	t.report()
+	return t.pass
+}
+
+func (t *test) addError(e error) *test {
+	t.errors = append(t.errors, e)
+	return t
+}
+
+func (t *test) report() {
+	fmt.Printf("%s : %s %s\n", result[t.pass], t.Method, t.Url)
+	if len(t.errors) > 0 {
+		for _, e := range t.errors {
 			fmt.Printf("  %s\n", e)
 		}
 	}
+}
 
-	return
+func (t *test) compare(prefix string, a, b map[string]interface{}) {
+	for k, v := range a {
+		switch av := v.(type) {
+		case map[string]interface{}:
+			switch bv := b[k].(type) {
+			case map[string]interface{}:
+				t.compare(fmt.Sprintf(prefix+".%s", k), av, bv)
+			default:
+				t.addError(fmt.Errorf("expected %s.%s == %v got %v", prefix, k, v, b[k]))
+			}
+
+		default:
+			if b[k] != v {
+				t.addError(fmt.Errorf("expected %s.%s == %v got %v", prefix, k, v, b[k]))
+			}
+		}
+	}
 }

--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -56,7 +56,7 @@ setup() {
 @test "SHOULD FAIL with response JSON != request JSON" {
   run ./emberfall --config ./tests/fail-req-res-json-no-match.yml
   assert_failure
-  assert_output --partial 'expected body.json.data.foo == bar got baz'
+  assert_output --partial 'expected body.json.data.foo == baz got bar'
 }
 
 @test "SHOULD PASS with response text" {
@@ -67,5 +67,5 @@ setup() {
 @test "SHOULD FAIL with response text no match" {
   run ./emberfall --config ./tests/fail-req-res-text-no-match.yml
   assert_failure
-  assert_output --partial 'expected body.json.data == bar got baz'
+  assert_output --partial 'expected body.json.data == baz got bar'
 }

--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -56,5 +56,16 @@ setup() {
 @test "SHOULD FAIL with response JSON != request JSON" {
   run ./emberfall --config ./tests/fail-req-res-json-no-match.yml
   assert_failure
-  assert_output --partial 'expected body.json.data.foo == baz got bar'
+  assert_output --partial 'expected body.json.data.foo == bar got baz'
+}
+
+@test "SHOULD PASS with response text" {
+  run ./emberfall --config ./tests/pass-req-res-text-match.yml
+  assert_success
+}
+
+@test "SHOULD FAIL with response text no match" {
+  run ./emberfall --config ./tests/fail-req-res-text-no-match.yml
+  assert_failure
+  assert_output --partial 'expected body.json.data == bar got baz'
 }

--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -42,10 +42,19 @@ setup() {
   assert_output --partial 'expected header x-no-exist was missing'
 }
 
-
 @test "SHOULD FAIL with bad url" {
   run ./emberfall --config ./tests/fail-bad-url.yml
   assert_failure
   assert_output --partial 'no such host'
 }
 
+@test "SHOULD PASS with response JSON == request JSON" {
+  run ./emberfall --config ./tests/pass-req-res-json-match.yml
+  assert_success
+}
+
+@test "SHOULD FAIL with response JSON != request JSON" {
+  run ./emberfall --config ./tests/fail-req-res-json-no-match.yml
+  assert_failure
+  assert_output --partial 'expected body.json.data.foo == baz got bar'
+}

--- a/tests/fail-req-res-json-no-match.yml
+++ b/tests/fail-req-res-json-no-match.yml
@@ -1,0 +1,13 @@
+tests:
+  - url: https://postman-echo.com/post
+    method: POST
+    follow: true
+    body:
+      json:
+        foo: "bar"
+    expect:
+      status: 200
+      body:
+        json:
+          data:
+            foo: "baz"

--- a/tests/fail-req-res-text-no-match.yml
+++ b/tests/fail-req-res-text-no-match.yml
@@ -1,0 +1,12 @@
+tests:
+  - url: https://postman-echo.com/post
+    method: POST
+    follow: true
+    body:
+      text: "bar"
+    expect:
+      status: 200
+      body:
+        # postman-echo always returns json
+        json: 
+          data: "baz"

--- a/tests/pass-req-res-json-match.yml
+++ b/tests/pass-req-res-json-match.yml
@@ -1,0 +1,13 @@
+tests:
+  - url: https://postman-echo.com/post
+    method: POST
+    follow: true
+    body:
+      json:
+        foo: "bar"
+    expect:
+      status: 200
+      body:
+        json:
+          data:
+            foo: "bar"

--- a/tests/pass-req-res-json-match.yml
+++ b/tests/pass-req-res-json-match.yml
@@ -1,7 +1,7 @@
+# test that request sends json and body receives json
 tests:
   - url: https://postman-echo.com/post
     method: POST
-    follow: true
     body:
       json:
         foo: "bar"

--- a/tests/pass-req-res-text-match.yml
+++ b/tests/pass-req-res-text-match.yml
@@ -1,3 +1,4 @@
+# test that request sends text
 tests:
   - url: https://postman-echo.com/post
     method: POST

--- a/tests/pass-req-res-text-match.yml
+++ b/tests/pass-req-res-text-match.yml
@@ -1,0 +1,12 @@
+tests:
+  - url: https://postman-echo.com/post
+    method: POST
+    follow: true
+    body:
+      text: "bar"
+    expect:
+      status: 200
+      body:
+        # postman-echo always returns json
+        json: 
+          data: "bar"


### PR DESCRIPTION
## Added
- Adds ability to specify request `body` as the following object to be sent with the request payload:
```yaml
tests:
- url: string
  body: 
    json: object # arbitrary key:value pairs marshaled and sent with `Content-Type=application/json`
    text: string # as plain text sent with `Content-Type=text/plain`
```
- Adds ability to specify response expectations match text or json as so:
```yaml
tests:
- url: string
  expect:
  body: 
    json: object # arbitrary key:value pairs marshaled and sent with `Content-Type=application/json`
    text: string # as plain text sent with `Content-Type=text/plain`
```
```
closes #18 