### PR TITLE
fix: resolved issue where expected numbers did not match responses when they should

### DIFF
--- a/internal/engine/test.go
+++ b/internal/engine/test.go
@@ -147,7 +147,7 @@ func (t *test) compare(prefix string, expect, actual map[string]interface{}) {
 				t.addError(fmt.Errorf("expected %s.%s == %s got %v", prefix, k, strconv.FormatFloat(expectedValue, 'f', -1, 64), actual[k]))
 			}
 
-		// yaml encodes integers to int, json encoides all numbers to float64
+		// yaml encodes integers to int, json encodes all numbers to float64
 		case int:
 			expectedNum := float64(expectedValue)
 			actualVal := actual[k]

--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -75,3 +75,45 @@ setup() {
   assert_success
   assert_output --partial 'PASS : GET https://postman-echo.com/baz'
 }
+
+@test "SHOULD PASS float equals float" {
+  run ./emberfall --config ./tests/pass-numbers-float-equals-float.yml
+  assert_success
+}
+
+@test "SHOULD PASS int equals int" {
+  run ./emberfall --config ./tests/pass-numbers-int-equals-int.yml
+  assert_success
+}
+
+@test "SHOULD FAIL int equals int" {
+  run ./emberfall --config ./tests/fail-numbers-int-equals-int.yml
+  assert_failure
+  assert_output --partial 'expected body.json.data.num == 1 got 2'
+}
+
+@test "SHOULD FAIL int equals float" {
+  run ./emberfall --config ./tests/fail-numbers-int-equals-float.yml
+  assert_failure
+  assert_output --partial 'expected body.json.data.num == 1 got 1.1'
+}
+
+@test "SHOULD FAIL float equals float" {
+  run ./emberfall --config ./tests/fail-numbers-float-equals-float.yml
+  assert_failure
+  assert_output --partial 'expected body.json.data.num == 2.2 got 3.3'
+}
+
+
+@test "SHOULD FAIL string equals float" {
+  run ./emberfall --config ./tests/fail-numbers-string-equals-float.yml
+  assert_failure
+  assert_output --partial 'expected body.json.data.num == 1 got 1.1'
+}
+
+
+@test "SHOULD FAIL string equals int" {
+  run ./emberfall --config ./tests/fail-numbers-string-equals-int.yml
+  assert_failure
+  assert_output --partial 'expected body.json.data.num == 1 got 2'
+}

--- a/tests/fail-numbers-float-equals-float.yml
+++ b/tests/fail-numbers-float-equals-float.yml
@@ -1,0 +1,13 @@
+# test that 2.2 == 3.3
+tests:
+  - url: https://postman-echo.com/post
+    method: POST
+    body:
+      json:
+        num: 3.3
+    expect:
+      status: 200
+      body:
+        json:
+          data:
+            num: 2.2

--- a/tests/fail-numbers-int-equals-float.yml
+++ b/tests/fail-numbers-int-equals-float.yml
@@ -1,0 +1,13 @@
+# test that 1.1 == 1
+tests:
+  - url: https://postman-echo.com/post
+    method: POST
+    body:
+      json:
+        num: 1.1
+    expect:
+      status: 200
+      body:
+        json:
+          data:
+            num: 1

--- a/tests/fail-numbers-int-equals-int.yml
+++ b/tests/fail-numbers-int-equals-int.yml
@@ -1,0 +1,13 @@
+# test that 1 == 2
+tests:
+  - url: https://postman-echo.com/post
+    method: POST
+    body:
+      json:
+        num: 2
+    expect:
+      status: 200
+      body:
+        json:
+          data:
+            num: 1

--- a/tests/fail-numbers-string-equals-float.yml
+++ b/tests/fail-numbers-string-equals-float.yml
@@ -1,0 +1,13 @@
+# test that "1" === 1.1 should fail
+tests:
+  - url: https://postman-echo.com/post
+    method: POST
+    body:
+      json:
+        num: 1.1
+    expect:
+      status: 200
+      body:
+        json:
+          data:
+            num: "1"

--- a/tests/fail-numbers-string-equals-int.yml
+++ b/tests/fail-numbers-string-equals-int.yml
@@ -1,0 +1,13 @@
+# test that "1" === 2 should fail
+tests:
+  - url: https://postman-echo.com/post
+    method: POST
+    body:
+      json:
+        num: 2
+    expect:
+      status: 200
+      body:
+        json:
+          data:
+            num: "1"

--- a/tests/pass-numbers-float-equals-float.yml
+++ b/tests/pass-numbers-float-equals-float.yml
@@ -1,0 +1,13 @@
+# test that 1 == 1
+tests:
+  - url: https://postman-echo.com/post
+    method: POST
+    body:
+      json:
+        num: 1.1
+    expect:
+      status: 200
+      body:
+        json:
+          data:
+            num: 1.1

--- a/tests/pass-numbers-int-equals-int.yml
+++ b/tests/pass-numbers-int-equals-int.yml
@@ -1,0 +1,13 @@
+# test that 1 == 1
+tests:
+  - url: https://postman-echo.com/post
+    method: POST
+    body:
+      json:
+        num: 1
+    expect:
+      status: 200
+      body:
+        json:
+          data:
+            num: 1


### PR DESCRIPTION
## Added 
Nothing new

## Changed
Added cases to `compare()` method to account for `int` and `float64` 