### PR TITLE
cicd: implemented input for file as path to emberfall tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,25 @@ Define tests in a YAML file like show above, and run emberfall: `emberfall --con
 
 ## As a Github Action
 
-```yaml
 
+```yaml
   uses: "aquia-inc/emberfall@main"
   with:
-   version: 0.3.0
+   version: 0.3.1
+   config: # string: YAML tests config inlined
+   file: # string: path/to/tests
+```
+
+> **_NOTE:_** when both `config` and `file` are specified, Emberfall will run _twice_ with `config` running first, and `file` running second.
+
+### Inlined Tests
+
+This is helpful for either short tests or for testing Emberfall integration with your workflow
+
+```yaml
+  uses: "aquia-inc/emberfall@main"
+  with:
+   version: 0.3.1
    config: | 
     ---
     tests:  
@@ -140,4 +154,13 @@ Define tests in a YAML file like show above, and run emberfall: `emberfall --con
             content-type: "text/html; charset=utf-8"
             content-language: en-US
       
+```
+
+### Tests in a file
+For longer tests it's best to place those in their own file like so
+```yaml
+  uses: "aquia-inc/emberfall@main"
+  with:
+   version: 0.3.1
+   file: path/to/tests.yml   
 ```

--- a/action.yml
+++ b/action.yml
@@ -7,8 +7,11 @@ inputs:
     description: "Emberfall version"
     required: true
   config:
-    description: "Emberfall tests config in YAML format"
-    required: true
+    description: "Emberfall tests inlined as string"
+    required: false
+  file:
+    description: "Path to Emberfall tests file"
+    required: false
 runs:
     using: "composite"
     steps:
@@ -40,10 +43,16 @@ runs:
           tar -C /tmp -xzf emberfall.tgz
           rm emberfall.tgz
           sudo mv /tmp/emberfall /usr/bin
-      
-      - name: Start emberfall
+
+      - name: Run Emberfall Tests - Inlined
         shell: bash
+        if: inputs.config != ''
         run: |
           echo "${{ inputs.config }}" > ./emberfallconfig.yml
           emberfall --config ./emberfallconfig.yml
+
+      - name: Run Emberfall Tests - File
+        shell: bash
+        if: inputs.file != ''
+        run: emberfall --config ${{ inputs.file }}
           


### PR DESCRIPTION
## Added
nothing new

## Changed
Added `file` input to github action to specify a file as a path/to/tests

closes #33 