### PR TITLE
fix: resolved issue where responses are not provided on errors

### DIFF
--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -104,16 +104,20 @@ setup() {
   assert_output --partial 'expected body.json.data.num == 2.2 got 3.3'
 }
 
-
 @test "SHOULD FAIL string equals float" {
   run ./emberfall --config ./tests/fail-numbers-string-equals-float.yml
   assert_failure
   assert_output --partial 'expected body.json.data.num == 1 got 1.1'
 }
 
-
 @test "SHOULD FAIL string equals int" {
   run ./emberfall --config ./tests/fail-numbers-string-equals-int.yml
   assert_failure
   assert_output --partial 'expected body.json.data.num == 1 got 2'
+}
+
+@test "SHOULD FAIL but body response gets printed" {
+  run ./emberfall --config ./tests/fail-response-printed.yml
+  assert_failure
+  assert_output --partial '"status": 400'
 }

--- a/tests/fail-response-printed.yml
+++ b/tests/fail-response-printed.yml
@@ -1,0 +1,12 @@
+tests:
+  - url: https://postman-echo.com/status/400
+    method: GET
+    follow: true
+    body:
+      json:
+        foo: "bar"
+    expect:
+      status: 200
+      body:
+        json:
+          status: 200


### PR DESCRIPTION
## Changed
- when a test fails, emberfall now prints the response body to help with debugging

## Added
- tests 

closes #27 