### PR TITLE
Fix action.yml CLI flags for v0.4.0+

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,10 +49,10 @@ runs:
         if: inputs.config != ''
         run: |
           echo "${{ inputs.config }}" > ./emberfallconfig.yml
-          emberfall --config ./emberfallconfig.yml
+          emberfall --tests ./emberfallconfig.yml
 
       - name: Run Emberfall Tests - File
         shell: bash
         if: inputs.file != ''
-        run: emberfall --config ${{ inputs.file }}
+        run: emberfall --tests ${{ inputs.file }}
           


### PR DESCRIPTION
## Summary
The `--config` flag was renamed to `--tests` in v0.4.0, but `action.yml` was not updated. This causes the GitHub Action to fail with `unknown flag: --config` when using `version: 0.4.0` or later.

## Changes
- `action.yml`: Replace `--config` with `--tests` in both the inlined and file-based test steps

## Context
Discovered when upgrading from v0.3.1 to v0.4.1 in [CMS-Enterprise/ztmf](https://github.com/CMS-Enterprise/ztmf). The binary downloaded correctly but the action passed the old flag name.