### PR TITLE
feat: support multipart/form-data request bodies with file attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,12 @@
 dist/
+
+# Compiled binary (built locally for bats tests; release artifacts go in dist/)
+/emberfall
+
+# Local AI assistant context (not committed)
+CLAUDE.md
+GEMINI.md
+AGENTS.md
+.claude/
+.gemini/
+.codex/

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ tests:
     text: string # to send as content-type text/plain
     json: object # to send as content-type application/json
       # arbitrary key:value pairs
+    multipart: object # to send as content-type multipart/form-data
+      fields: object # optional, key:value form fields
+      files: object # optional, form-field-name:local-file-path
+        # paths are resolved relative to the working directory; per-file
+        # Content-Type is derived from the file extension
   expect:
     status: int # a supported HTTP status code such as 200,201,301,400,404, etc...
     body: object # optional
@@ -89,6 +94,26 @@ tests:
         name: "John Doe"
 
 ```
+### Multipart Form Uploads
+
+Use `body.multipart` to send `multipart/form-data` requests. `fields` carries plain
+key/value form parts and `files` maps a form field name to a local file path. File
+sizes are capped at 50 MiB per attachment.
+
+```yaml
+tests:
+- url: http://localhost:3000/api/upload
+  method: POST
+  body:
+    multipart:
+      fields:
+        category: "resume"
+      files:
+        file: ./fixtures/resume.pdf
+  expect:
+    status: 202
+```
+
 ### Advanced Tests Configuration
 The following highlights ways to leverage YAML anchors for common values between tests. Here we use `commonHeaders` (an arbitrary name) as a YAML anchor to reuse when needed:
 ```yaml

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -79,8 +79,9 @@ func Run(cfg *Config) error {
 			bodyTypes++
 		}
 		if bodyTypes > 1 {
+			// Falls through to the post-NewRequest guard for reporting; no
+			// request is sent because that guard short-circuits before client.Do.
 			test.addError(errors.New("body may define only one of json, text, or multipart"))
-			continue
 		}
 
 		var contentType string

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -43,9 +43,8 @@ func Run(cfg *Config) error {
 	// TODO: refactor this loop into Tests.run() by making config.Tests type Tests as []*test
 	for _, test := range cfg.Tests {
 		var (
-			err  error
-			body []byte
-			res  *http.Response
+			err error
+			res *http.Response
 		)
 
 		reqBuf.Truncate(0)
@@ -87,7 +86,7 @@ func Run(cfg *Config) error {
 		var contentType string
 
 		if test.Body.Json != nil {
-			body, err = json.Marshal(test.Body.Json)
+			body, err := json.Marshal(test.Body.Json)
 			if err != nil {
 				test.addError(err)
 				continue
@@ -102,6 +101,9 @@ func Run(cfg *Config) error {
 		}
 
 		if test.Body.Multipart != nil {
+			// Errors fall through to the post-NewRequest guard (test.errors > 0)
+			// rather than continuing here; the partial buffer is harmless because
+			// no request is sent and Truncate(0) clears it on the next iteration.
 			contentType, err = writeMultipart(reqBuf, test.Body.Multipart)
 			if err != nil {
 				test.addError(err)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -69,10 +69,22 @@ func Run(cfg *Config) error {
 			continue
 		}
 
-		if test.Body.Json != nil && test.Body.Text != nil {
-			test.addError(errors.New("may define body.json or body.text but not both"))
+		bodyTypes := 0
+		if test.Body.Json != nil {
+			bodyTypes++
+		}
+		if test.Body.Text != nil {
+			bodyTypes++
+		}
+		if test.Body.Multipart != nil {
+			bodyTypes++
+		}
+		if bodyTypes > 1 {
+			test.addError(errors.New("body may define only one of json, text, or multipart"))
 			continue
 		}
+
+		var contentType string
 
 		if test.Body.Json != nil {
 			body, err = json.Marshal(test.Body.Json)
@@ -80,20 +92,27 @@ func Run(cfg *Config) error {
 				test.addError(err)
 				continue
 			}
-
-			if _, ok := test.Headers["Content-Type"]; !ok {
-				test.Headers["Content-Type"] = "application/json"
-			}
+			reqBuf.Write(body)
+			contentType = "application/json"
 		}
 
 		if test.Body.Text != nil {
-			body = []byte(*test.Body.Text)
-			if _, ok := test.Headers["Content-Type"]; !ok {
-				test.Headers["Content-Type"] = "text/plain"
+			reqBuf.WriteString(*test.Body.Text)
+			contentType = "text/plain"
+		}
+
+		if test.Body.Multipart != nil {
+			contentType, err = writeMultipart(reqBuf, test.Body.Multipart)
+			if err != nil {
+				test.addError(err)
 			}
 		}
 
-		reqBuf.Write(body)
+		if contentType != "" {
+			if _, ok := test.Headers["Content-Type"]; !ok {
+				test.Headers["Content-Type"] = contentType
+			}
+		}
 
 		req, err = http.NewRequest(test.Method, test.Url, reqBuf)
 

--- a/internal/engine/multipart.go
+++ b/internal/engine/multipart.go
@@ -9,7 +9,13 @@ import (
 	"net/textproto"
 	"os"
 	"path/filepath"
+	"strings"
 )
+
+// maxMultipartFileSize caps in-memory buffering of any single uploaded file to
+// guard against runaway YAML referencing /dev/urandom, sparse files, or other
+// large inputs that would balloon the request buffer.
+const maxMultipartFileSize = 50 * 1024 * 1024 // 50 MiB
 
 // writeMultipart writes a multipart/form-data payload into buf and returns the
 // Content-Type (including the generated boundary). File parts use a Content-Type
@@ -19,12 +25,18 @@ func writeMultipart(buf *bytes.Buffer, m *multipartBody) (string, error) {
 	w := multipart.NewWriter(buf)
 
 	for k, v := range m.Fields {
+		if err := validatePartName("field", k); err != nil {
+			return "", err
+		}
 		if err := w.WriteField(k, v); err != nil {
 			return "", err
 		}
 	}
 
 	for field, path := range m.Files {
+		if err := validatePartName("file form name", field); err != nil {
+			return "", err
+		}
 		if err := writeFilePart(w, field, path); err != nil {
 			return "", err
 		}
@@ -34,6 +46,15 @@ func writeMultipart(buf *bytes.Buffer, m *multipartBody) (string, error) {
 		return "", err
 	}
 	return w.FormDataContentType(), nil
+}
+
+// validatePartName rejects names that would let a YAML author inject extra
+// MIME headers via CR, LF, or NUL bytes in the part's Content-Disposition.
+func validatePartName(kind, name string) error {
+	if strings.ContainsAny(name, "\r\n\x00") {
+		return fmt.Errorf("multipart %s name contains forbidden control characters: %q", kind, name)
+	}
+	return nil
 }
 
 func writeFilePart(w *multipart.Writer, field, path string) error {
@@ -56,8 +77,14 @@ func writeFilePart(w *multipart.Writer, field, path string) error {
 	if err != nil {
 		return err
 	}
-	if _, err := io.Copy(part, f); err != nil {
+
+	limited := &io.LimitedReader{R: f, N: maxMultipartFileSize + 1}
+	n, err := io.Copy(part, limited)
+	if err != nil {
 		return err
+	}
+	if n > maxMultipartFileSize {
+		return fmt.Errorf("multipart file %q exceeds %d byte limit", path, maxMultipartFileSize)
 	}
 	return nil
 }

--- a/internal/engine/multipart.go
+++ b/internal/engine/multipart.go
@@ -32,6 +32,10 @@ var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
 // Content-Type (including the generated boundary). File parts use a Content-Type
 // derived from the file extension, falling back to application/octet-stream.
 // File paths are resolved relative to the process working directory.
+//
+// Part ordering follows Go's randomized map iteration, so fields and files may
+// appear in different orders across runs. Servers that depend on multipart
+// part ordering are not currently supported.
 func writeMultipart(buf *bytes.Buffer, m *multipartBody) (string, error) {
 	w := multipart.NewWriter(buf)
 
@@ -73,6 +77,13 @@ func validatePartName(kind, name string) error {
 }
 
 func writeFilePart(w *multipart.Writer, field, path string) error {
+	if err := validatePartName("file path", path); err != nil {
+		return err
+	}
+	if err := validatePartName("file name", filepath.Base(path)); err != nil {
+		return err
+	}
+
 	f, err := os.Open(path)
 	if err != nil {
 		return fmt.Errorf("multipart file %q: %w", path, err)

--- a/internal/engine/multipart.go
+++ b/internal/engine/multipart.go
@@ -1,0 +1,63 @@
+package engine
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/textproto"
+	"os"
+	"path/filepath"
+)
+
+// writeMultipart writes a multipart/form-data payload into buf and returns the
+// Content-Type (including the generated boundary). File parts use a Content-Type
+// derived from the file extension, falling back to application/octet-stream.
+// File paths are resolved relative to the process working directory.
+func writeMultipart(buf *bytes.Buffer, m *multipartBody) (string, error) {
+	w := multipart.NewWriter(buf)
+
+	for k, v := range m.Fields {
+		if err := w.WriteField(k, v); err != nil {
+			return "", err
+		}
+	}
+
+	for field, path := range m.Files {
+		if err := writeFilePart(w, field, path); err != nil {
+			return "", err
+		}
+	}
+
+	if err := w.Close(); err != nil {
+		return "", err
+	}
+	return w.FormDataContentType(), nil
+}
+
+func writeFilePart(w *multipart.Writer, field, path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("multipart file %q: %w", path, err)
+	}
+	defer f.Close()
+
+	ctype := mime.TypeByExtension(filepath.Ext(path))
+	if ctype == "" {
+		ctype = "application/octet-stream"
+	}
+
+	h := textproto.MIMEHeader{}
+	h.Set("Content-Disposition", fmt.Sprintf(`form-data; name=%q; filename=%q`, field, filepath.Base(path)))
+	h.Set("Content-Type", ctype)
+
+	part, err := w.CreatePart(h)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(part, f); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/engine/multipart.go
+++ b/internal/engine/multipart.go
@@ -10,12 +10,23 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode"
 )
 
-// maxMultipartFileSize caps in-memory buffering of any single uploaded file to
-// guard against runaway YAML referencing /dev/urandom, sparse files, or other
-// large inputs that would balloon the request buffer.
+// maxMultipartFileSize caps the in-memory buffering of each individual file part
+// so a YAML pointing at /dev/urandom, a sparse file, or any unexpectedly large
+// input cannot balloon the request buffer. The limit is per file, not aggregate
+// across all files in a single test; configurations with many large attachments
+// should still be sized with the operator's available memory in mind.
 const maxMultipartFileSize = 50 * 1024 * 1024 // 50 MiB
+
+// quoteEscaper mirrors the stdlib's mime/multipart.escapeQuotes (which is
+// unexported) so that field and filename values are quoted the same way
+// CreateFormFile would do it. Non-ASCII bytes are passed through as raw UTF-8,
+// which lenient servers parse correctly. Strict RFC 5987 (filename*=UTF-8''...)
+// encoding is not implemented; non-ASCII filenames may not interoperate with
+// servers that reject anything outside the legacy quoted-string form.
+var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
 
 // writeMultipart writes a multipart/form-data payload into buf and returns the
 // Content-Type (including the generated boundary). File parts use a Content-Type
@@ -48,11 +59,15 @@ func writeMultipart(buf *bytes.Buffer, m *multipartBody) (string, error) {
 	return w.FormDataContentType(), nil
 }
 
-// validatePartName rejects names that would let a YAML author inject extra
-// MIME headers via CR, LF, or NUL bytes in the part's Content-Disposition.
+// validatePartName rejects names containing any control character so a YAML
+// author cannot inject extra MIME headers (via CR/LF/NUL) or produce
+// syntactically invalid Content-Disposition parameters (via other control
+// bytes that bypass the quoted-string escape but still violate RFC 7230).
 func validatePartName(kind, name string) error {
-	if strings.ContainsAny(name, "\r\n\x00") {
-		return fmt.Errorf("multipart %s name contains forbidden control characters: %q", kind, name)
+	for _, r := range name {
+		if unicode.IsControl(r) {
+			return fmt.Errorf("multipart %s name contains forbidden control characters: %q", kind, name)
+		}
 	}
 	return nil
 }
@@ -70,7 +85,9 @@ func writeFilePart(w *multipart.Writer, field, path string) error {
 	}
 
 	h := textproto.MIMEHeader{}
-	h.Set("Content-Disposition", fmt.Sprintf(`form-data; name=%q; filename=%q`, field, filepath.Base(path)))
+	h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"; filename="%s"`,
+		quoteEscaper.Replace(field),
+		quoteEscaper.Replace(filepath.Base(path))))
 	h.Set("Content-Type", ctype)
 
 	part, err := w.CreatePart(h)

--- a/internal/engine/test.go
+++ b/internal/engine/test.go
@@ -18,8 +18,14 @@ var (
 // it is not unmarshaled directly into test{}
 // json tags here for for the encode/decode process used in newTest to convert interface{}
 type body struct {
-	Json map[string]interface{} `yaml:"json,omitempty"`
-	Text *string                `yaml:"text,omitempty"`
+	Json      map[string]interface{} `yaml:"json,omitempty"`
+	Text      *string                `yaml:"text,omitempty"`
+	Multipart *multipartBody         `yaml:"multipart,omitempty"`
+}
+
+type multipartBody struct {
+	Fields map[string]string `yaml:"fields,omitempty"`
+	Files  map[string]string `yaml:"files,omitempty"`
 }
 
 type expect struct {

--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -191,3 +191,23 @@ setup() {
   assert_success
   assert_output --partial 'PASS'
 }
+
+@test "SHOULD PASS with multipart form fields" {
+  run ./emberfall --tests ./tests/pass-multipart-fields.yml
+  assert_success
+  assert_output --partial 'PASS'
+}
+
+@test "SHOULD PASS with multipart file attachment" {
+  run ./emberfall --tests ./tests/pass-multipart-file.yml
+  assert_success
+  assert_output --partial 'PASS'
+}
+
+@test "SHOULD FAIL with multipart referencing missing file" {
+  run ./emberfall --tests ./tests/fail-multipart-missing-file.yml
+  assert_failure
+  assert_output --partial 'FAIL'
+  assert_output --partial 'multipart file'
+  assert_output --partial 'does-not-exist.pdf'
+}

--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -211,3 +211,10 @@ setup() {
   assert_output --partial 'multipart file'
   assert_output --partial 'does-not-exist.pdf'
 }
+
+@test "SHOULD FAIL with multipart field name containing CRLF" {
+  run ./emberfall --tests ./tests/fail-multipart-crlf-injection.yml
+  assert_failure
+  assert_output --partial 'FAIL'
+  assert_output --partial 'forbidden control characters'
+}

--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -218,3 +218,17 @@ setup() {
   assert_output --partial 'FAIL'
   assert_output --partial 'forbidden control characters'
 }
+
+@test "SHOULD FAIL with multipart filename containing CRLF" {
+  run ./emberfall --tests ./tests/fail-multipart-filename-crlf.yml
+  assert_failure
+  assert_output --partial 'FAIL'
+  assert_output --partial 'forbidden control characters'
+}
+
+@test "SHOULD FAIL with both multipart and json bodies" {
+  run ./emberfall --tests ./tests/fail-multipart-and-json.yml
+  assert_failure
+  assert_output --partial 'FAIL'
+  assert_output --partial 'body may define only one of json, text, or multipart'
+}

--- a/tests/fail-multipart-and-json.yml
+++ b/tests/fail-multipart-and-json.yml
@@ -1,0 +1,13 @@
+# test that the body mutual-exclusion check rejects a request defining both
+# multipart and json bodies; the guard fires before any request is sent.
+tests:
+  - url: http://127.0.0.1:0/post
+    method: POST
+    body:
+      json:
+        foo: "bar"
+      multipart:
+        fields:
+          name: "value"
+    expect:
+      status: 200

--- a/tests/fail-multipart-crlf-injection.yml
+++ b/tests/fail-multipart-crlf-injection.yml
@@ -1,0 +1,11 @@
+# test that multipart field names containing control characters are rejected
+# before any request is sent, blocking MIME header injection via the YAML.
+tests:
+  - url: https://postman-echo.com/post
+    method: POST
+    body:
+      multipart:
+        fields:
+          "name\r\nX-Injected: evil": "value"
+    expect:
+      status: 200

--- a/tests/fail-multipart-crlf-injection.yml
+++ b/tests/fail-multipart-crlf-injection.yml
@@ -1,7 +1,9 @@
 # test that multipart field names containing control characters are rejected
 # before any request is sent, blocking MIME header injection via the YAML.
+# URL is non-routable on purpose: validation must fail before the network is
+# touched, so this test never depends on external infrastructure.
 tests:
-  - url: https://postman-echo.com/post
+  - url: http://127.0.0.1:0/post
     method: POST
     body:
       multipart:

--- a/tests/fail-multipart-filename-crlf.yml
+++ b/tests/fail-multipart-filename-crlf.yml
@@ -1,0 +1,12 @@
+# test that a file path whose basename contains control characters is
+# rejected before open(), blocking MIME header injection via the filename
+# parameter of Content-Disposition.
+tests:
+  - url: http://127.0.0.1:0/post
+    method: POST
+    body:
+      multipart:
+        files:
+          file: "./fixtures/evil\r\nX-Injected: bad.txt"
+    expect:
+      status: 200

--- a/tests/fail-multipart-missing-file.yml
+++ b/tests/fail-multipart-missing-file.yml
@@ -1,0 +1,10 @@
+# test that multipart/form-data with a missing file path fails clearly
+tests:
+  - url: https://postman-echo.com/post
+    method: POST
+    body:
+      multipart:
+        files:
+          file: ./tests/fixtures/does-not-exist.pdf
+    expect:
+      status: 200

--- a/tests/fail-multipart-missing-file.yml
+++ b/tests/fail-multipart-missing-file.yml
@@ -1,6 +1,8 @@
-# test that multipart/form-data with a missing file path fails clearly
+# test that multipart/form-data with a missing file path fails clearly.
+# URL is non-routable on purpose: the open() error fires before the network
+# is touched, so this test never depends on external infrastructure.
 tests:
-  - url: https://postman-echo.com/post
+  - url: http://127.0.0.1:0/post
     method: POST
     body:
       multipart:

--- a/tests/fixtures/sample.txt
+++ b/tests/fixtures/sample.txt
@@ -1,0 +1,1 @@
+sample upload

--- a/tests/pass-multipart-fields.yml
+++ b/tests/pass-multipart-fields.yml
@@ -1,0 +1,16 @@
+# test that multipart/form-data fields are sent and echoed back
+tests:
+  - url: https://postman-echo.com/post
+    method: POST
+    body:
+      multipart:
+        fields:
+          name: "document.pdf"
+          category: "resume"
+    expect:
+      status: 200
+      body:
+        json:
+          form:
+            name: "document.pdf"
+            category: "resume"

--- a/tests/pass-multipart-file.yml
+++ b/tests/pass-multipart-file.yml
@@ -1,4 +1,8 @@
 # test that multipart/form-data file attachments are sent and echoed back
+#
+# postman-echo keys the `files` map by filename (not the form field name) and
+# returns file content as a base64 data URI. The base64 below decodes to
+# "sample upload\n" (the contents of tests/fixtures/sample.txt).
 tests:
   - url: https://postman-echo.com/post
     method: POST
@@ -14,3 +18,5 @@ tests:
         json:
           form:
             type: "standard"
+          files:
+            sample.txt: "data:application/octet-stream;base64,c2FtcGxlIHVwbG9hZAo="

--- a/tests/pass-multipart-file.yml
+++ b/tests/pass-multipart-file.yml
@@ -1,0 +1,16 @@
+# test that multipart/form-data file attachments are sent and echoed back
+tests:
+  - url: https://postman-echo.com/post
+    method: POST
+    body:
+      multipart:
+        fields:
+          type: "standard"
+        files:
+          file: ./tests/fixtures/sample.txt
+    expect:
+      status: 200
+      body:
+        json:
+          form:
+            type: "standard"


### PR DESCRIPTION
## Summary

Adds a `multipart` body type to test definitions, with `fields` for plain key/value form parts and `files` for local-path file attachments. Closes #52 and #53.

## Changes

- `internal/engine/test.go`: add `multipartBody` struct and `body.Multipart` field
- `internal/engine/multipart.go`: new helper that builds the multipart payload, derives per-file `Content-Type` from the extension, and caps each file at 50 MiB to bound in-memory buffering
- `internal/engine/engine.go`: route the multipart branch through the existing body-building flow, expand the body mutual-exclusion guard to cover `multipart`, and surface validation errors through the post-`NewRequest` reporter so they are counted as failed tests
- Reject any control character (`\r`, `\n`, `\x00`, and the rest of the C0/C1 range) in field names, file form names, file paths, and basenames so a YAML author cannot inject extra MIME headers via `Content-Disposition`
- Quote field and filename parameters with the same `quoteEscaper` pattern that `mime/multipart.CreateFormFile` uses, keeping non-ASCII filenames as raw UTF-8 for lenient-server interop
- `tests/`: fixtures and bats coverage for fields-only, fields + file echo, missing file error, CRLF rejection on field names, CRLF rejection on filenames, and the body mutual-exclusion guard
- `README.md`: schema reference and a usage example for the new option
- `.gitignore`: exclude the locally built `emberfall` binary so it does not get committed alongside source changes

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] All 36 bats cases pass: `bats tests/cli.bats` (30 pre-existing + 6 new)
- [x] Fields-only round-trip echoes through `postman-echo.com/post`
- [x] File attachment round-trip asserts the deterministic base64 echo of the upload
- [x] Missing file path produces a clear `multipart file ... no such file or directory` error and is counted as a failed test
- [x] Field name with embedded `\r\n` is rejected before the request is built
- [x] File path with embedded `\r\n` in the basename is rejected before `os.Open`
- [x] Defining both `multipart` and `json` on the same test is rejected with `body may define only one of json, text, or multipart`