### PR TITLE
chore(release): bump version to 0.5.0

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,7 +40,7 @@ tests:
     headers: object # optional, headers expected to be present in the response
       # key:value pairs 
 	`,
-	Version: "0.4.1",
+	Version: "0.5.0",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return engine.Run(config)
 	},

--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -7,7 +7,7 @@ setup() {
 @test "--version should be correct" {
   run ./emberfall --version
   assert_success
-  assert_output "emberfall version 0.4.1"
+  assert_output "emberfall version 0.5.0"
 }
 
 @test "no config SHOULD FAIL" {


### PR DESCRIPTION
Bumps the `cmd/root.go` version constant from 0.4.1 to 0.5.0 ahead of tagging `v0.5.0`.

`main` has carried the file-attachment feature (#56, a `feat`) since v0.4.1, so the released version is a minor bump behind and `emberfall --version` under-reports. This is the manual bootstrap for that release; #49 will automate it going forward.

After merge: tag `v0.5.0` on main to trigger the release pipeline (GoReleaser + brew formula update).

Closes #58