### PR TITLE
docs(copilot): add conventional commit guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,7 @@ When generating or suggesting a commit message or pull request title:
 - Prefer the types `feat`, `fix`, `perf`, `docs`, `refactor`, `test`, `build`, `ci`, `chore`, and `revert`.
 - Use a lowercase type and scope, an imperative description, and no trailing period.
 - Include a scope only when it makes the affected area clearer.
-- Mark breaking changes with `!` before the colon and explain the break in the commit or pull request body.
+- For commit messages, mark breaking changes with `!` before the colon or a `BREAKING CHANGE: <description>` footer; both are allowed. If using `!`, describe the break in the subject. For pull request titles, use `!`, describe the break in the title, and explain it in the pull request body.
 - Base the pull request title on the complete diff. Do not prefix it with a branch name, issue number, emoji, or labels such as `PR`.
 
 Examples:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,15 +6,11 @@ When generating or suggesting a commit message or pull request title:
 
 - Use [Conventional Commits](https://www.conventionalcommits.org/) syntax:
   `<type>(<optional-scope>): <description>`.
-- Prefer the types `feat`, `fix`, `perf`, `docs`, `refactor`, `test`, `build`,
-  `ci`, `chore`, and `revert`.
-- Use a lowercase type and scope, an imperative description, and no trailing
-  period.
+- Prefer the types `feat`, `fix`, `perf`, `docs`, `refactor`, `test`, `build`, `ci`, `chore`, and `revert`.
+- Use a lowercase type and scope, an imperative description, and no trailing period.
 - Include a scope only when it makes the affected area clearer.
-- Mark breaking changes with `!` before the colon and explain the break in the
-  commit or pull request body.
-- Base the pull request title on the complete diff. Do not prefix it with a
-  branch name, issue number, emoji, or labels such as `PR`.
+- Mark breaking changes with `!` before the colon and explain the break in the commit or pull request body.
+- Base the pull request title on the complete diff. Do not prefix it with a branch name, issue number, emoji, or labels such as `PR`.
 
 Examples:
 
@@ -22,6 +18,4 @@ Examples:
 - `docs: clarify the release process`
 - `refactor(engine)!: replace the request configuration format`
 
-Keep pull request descriptions concise and include the motivation, material
-changes, validation performed, and related issues. Follow `CONTRIBUTING.md` for
-the repository's complete contribution requirements.
+Keep pull request descriptions concise and include the motivation, material changes, validation performed, and related issues. Follow `CONTRIBUTING.md` for the repository's complete contribution requirements.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,27 @@
+# GitHub Copilot repository instructions
+
+## Commits and pull requests
+
+When generating or suggesting a commit message or pull request title:
+
+- Use [Conventional Commits](https://www.conventionalcommits.org/) syntax:
+  `<type>(<optional-scope>): <description>`.
+- Prefer the types `feat`, `fix`, `perf`, `docs`, `refactor`, `test`, `build`,
+  `ci`, `chore`, and `revert`.
+- Use a lowercase type and scope, an imperative description, and no trailing
+  period.
+- Include a scope only when it makes the affected area clearer.
+- Mark breaking changes with `!` before the colon and explain the break in the
+  commit or pull request body.
+- Base the pull request title on the complete diff. Do not prefix it with a
+  branch name, issue number, emoji, or labels such as `PR`.
+
+Examples:
+
+- `feat(cli): support multipart uploads`
+- `docs: clarify the release process`
+- `refactor(engine)!: replace the request configuration format`
+
+Keep pull request descriptions concise and include the motivation, material
+changes, validation performed, and related issues. Follow `CONTRIBUTING.md` for
+the repository's complete contribution requirements.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,8 +31,8 @@ changelog:
   sort: asc
   filters:
     exclude:
-      - "^docs:"
-      - "^test:"
+      - '^docs(\([^)]+\))?:'
+      - '^test(\([^)]+\))?:'
 
 brews:
   - name: emberfall


### PR DESCRIPTION
## Summary

Adds repository-wide GitHub Copilot instructions for generating Conventional
Commit messages and pull request titles.

## Related Issues

- Closes #62

## Motivation

`CONTRIBUTING.md` already requires Conventional Commits, but Copilot did not
have dedicated repository instructions reflecting that policy. As a result,
Copilot-generated suggestions could omit the required type, scope, or concise
imperative description.

GitHub documents `.github/copilot-instructions.md` as its repository-wide
Copilot instruction file. Adding it aligns supported Copilot interactions with
the contribution standard contributors already follow.

## Changes

- Add `.github/copilot-instructions.md`.
- Define the Conventional Commit format for suggested commit messages and pull
  request titles.
- List the preferred commit types and breaking-change syntax.
- Provide representative title examples.
- Direct Copilot to consider the complete diff and follow `CONTRIBUTING.md`.

## Validation

- `go test ./...`
- `git diff HEAD^ HEAD --check`

## Scope

This is an instructions-only change. It does not modify Emberfall's runtime,
build, release, or workflow behavior.
