### PR TITLE
docs: sync README CLI usage and examples with the shipped binary

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,6 +15,9 @@ jobs:
       
       - uses: actions/setup-go@v5
 
+      - name: Test Go
+        run: go test ./...
+
       - name: Compile
         run: go build -o ./ ./...
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Flags:
 ```
 > **_NOTE:_**  When using `--url` the value provided will be compiled as a Go-compatible regular expression and used to match against the `url` field for each test. To define multiple tests use the pipe symbol (|), for example to include foo, bar, and baz use `--url 'foo|bar|baz'`. To include all tests without TLS (that start with `http:`) use `--url '^http:'`. To include all tests that contain users, but excludes sub-resources (like users/<id>/comments) use `--url '\/users(\/?\d+)$'` (be sure to use single quotes to avoid shell expansion)
 
-> **_NOTE:_**  `--method` works the same way, matching against the `method` field for each test. Use `--method 'POST|PUT'` to run only the tests that write, or `--method '^GET$'` to run only reads. `--url` and `--method` combine, so `--url '/users' --method '^GET$'` selects the tests that satisfy both.
+> **_NOTE:_**  `--method` works the same way, matching against each test's `method` field as written in the config. Use `--method '^GET$'` to run only reads, or `--method 'POST|PUT|PATCH|DELETE'` to run only tests that write. `--url` and `--method` combine, so `--url '/users' --method '^GET$'` selects the tests that satisfy both. A test that omits `method:` sends a GET at request time but has an empty `method` field, so method filters will not match it.
 
 ## Configuring Tests
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,15 @@ Simply declare a list of URLs along with their expected response values, and Emb
 emberfall [flags]
 
 Flags:
-  -c, --tests string    Path to tests config file. - to read from stdin (default "-")
   -h, --help            help for emberfall
+  -m, --method string   Regular expression to include only tests with a matching method
+  -t, --tests string    Path to tests configuration file. - to read from stdin (default "-")
   -u, --url string      Regular expression to include only tests with a matching url
   -v, --version         version for emberfall
 ```
 > **_NOTE:_**  When using `--url` the value provided will be compiled as a Go-compatible regular expression and used to match against the `url` field for each test. To define multiple tests use the pipe symbol (|), for example to include foo, bar, and baz use `--url 'foo|bar|baz'`. To include all tests without TLS (that start with `http:`) use `--url '^http:'`. To include all tests that contain users, but excludes sub-resources (like users/<id>/comments) use `--url '\/users(\/?\d+)$'` (be sure to use single quotes to avoid shell expansion)
+
+> **_NOTE:_**  `--method` works the same way, matching against the `method` field for each test. Use `--method 'POST|PUT'` to run only the tests that write, or `--method '^GET$'` to run only reads. `--url` and `--method` combine, so `--url '/users' --method '^GET$'` selects the tests that satisfy both.
 
 ## Configuring Tests
 
@@ -62,7 +65,8 @@ tests:
   method: GET
   expect:
     status: 401
-    body: "unauthorized"
+    body:
+      text: "unauthorized"
 ```
 
 ### Reponse References
@@ -126,7 +130,8 @@ tests:
   method: GET
   expect:
     status: 401
-    body: "unauthorized"
+    body:
+      text: "unauthorized"
   
   # ensure including authorization header returns current user
 - url: http://localhost:3000/api/v1/users/current
@@ -164,7 +169,7 @@ Define tests in a YAML file like show above, and run emberfall: `emberfall --tes
 ```yaml
   uses: "aquia-inc/emberfall@main"
   with:
-   version: 0.4.0
+   version: 0.5.0
    config: # string: YAML tests config inlined
    file: # string: path/to/tests
 ```
@@ -178,7 +183,7 @@ This is helpful for either short tests or for testing Emberfall integration with
 ```yaml
   uses: "aquia-inc/emberfall@main"
   with:
-   version: 0.4.0
+   version: 0.5.0
    config: | 
     ---
     tests:  
@@ -198,6 +203,6 @@ For longer tests it's best to place those in their own file like so
 ```yaml
   uses: "aquia-inc/emberfall@main"
   with:
-   version: 0.4.0
+   version: 0.5.0
    file: path/to/tests.yml   
 ```

--- a/cmd/docs_test.go
+++ b/cmd/docs_test.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/aquia-inc/emberfall/internal/engine"
+	"gopkg.in/yaml.v3"
+)
+
+const readmePath = "../README.md"
+
+// readREADME returns the README with line-trailing whitespace removed so
+// comparisons do not turn on invisible characters.
+func readREADME(t *testing.T) string {
+	t.Helper()
+	contents, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read %s: %v", readmePath, err)
+	}
+	return trimLineEnds(string(contents))
+}
+
+func trimLineEnds(value string) string {
+	lines := strings.Split(strings.ReplaceAll(value, "\r\n", "\n"), "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, " \t")
+	}
+	return strings.Join(lines, "\n")
+}
+
+// helpSchema returns the YAML schema embedded in the root command's long help,
+// starting at its "tests:" root.
+func helpSchema(t *testing.T) string {
+	t.Helper()
+	long := trimLineEnds(rootCmd.Long)
+	start := strings.Index(long, "\ntests:\n")
+	if start < 0 {
+		t.Fatal("root command long help no longer contains a tests: schema")
+	}
+	return strings.TrimSpace(long[start+1:])
+}
+
+// yamlBlocks returns the contents of every ```yaml fenced block in markdown.
+func yamlBlocks(markdown string) []string {
+	var blocks []string
+	var current []string
+	inBlock := false
+	for line := range strings.SplitSeq(markdown, "\n") {
+		if !inBlock {
+			if strings.TrimSpace(line) == "```yaml" {
+				inBlock = true
+				current = nil
+			}
+			continue
+		}
+		if strings.TrimSpace(line) == "```" {
+			blocks = append(blocks, strings.Join(current, "\n"))
+			inBlock = false
+			continue
+		}
+		current = append(current, line)
+	}
+	return blocks
+}
+
+// The README's CLI Usage block is copied from cobra, so a new or renamed flag
+// has to be reflected in the docs before this passes.
+func TestREADMEFlagBlockMatchesCLI(t *testing.T) {
+	rootCmd.InitDefaultHelpFlag()
+	rootCmd.InitDefaultVersionFlag()
+
+	want := trimLineEnds(rootCmd.Flags().FlagUsages())
+	if strings.TrimSpace(want) == "" {
+		t.Fatal("cobra reported no flags")
+	}
+	if !strings.Contains(readREADME(t), want) {
+		t.Errorf("README CLI Usage block is out of sync with the registered flags.\nExpected it to contain:\n%s", want)
+	}
+}
+
+// The README documents the same schema the binary prints, so a schema change in
+// one place has to be made in the other.
+func TestREADMESchemaMatchesHelp(t *testing.T) {
+	want := helpSchema(t)
+	for _, block := range yamlBlocks(readREADME(t)) {
+		if strings.TrimSpace(block) == want {
+			return
+		}
+	}
+	t.Errorf("No README yaml block matches the schema printed by --help.\nExpected a block containing:\n%s", want)
+}
+
+// Every example config in the README has to unmarshal, so a documented example
+// cannot abort at parse time the way the pre-#65 expect.body examples did.
+func TestREADMEExampleConfigsParse(t *testing.T) {
+	schema := helpSchema(t)
+	examples := 0
+	for index, block := range yamlBlocks(readREADME(t)) {
+		// The schema block describes field types rather than values.
+		if strings.TrimSpace(block) == schema {
+			continue
+		}
+		if !strings.HasPrefix(block, "tests:") && !strings.Contains(block, "\ntests:") {
+			continue
+		}
+		examples++
+
+		var config engine.Config
+		if err := yaml.Unmarshal([]byte(block), &config); err != nil {
+			t.Errorf("README yaml block %d does not parse as a tests config: %v\n%s", index, err, block)
+			continue
+		}
+		if len(config.Tests) == 0 {
+			t.Errorf("README yaml block %d parsed to zero tests:\n%s", index, block)
+		}
+	}
+	if examples == 0 {
+		t.Fatal("found no README example configs to validate")
+	}
+}

--- a/cmd/docs_test.go
+++ b/cmd/docs_test.go
@@ -43,13 +43,17 @@ func helpSchema(t *testing.T) string {
 }
 
 // yamlBlocks returns the contents of every ```yaml fenced block in markdown.
-func yamlBlocks(markdown string) []string {
+// An unterminated fence fails the test rather than silently dropping the block
+// from coverage.
+func yamlBlocks(t *testing.T, markdown string) []string {
+	t.Helper()
 	var blocks []string
 	var current []string
 	inBlock := false
 	for line := range strings.SplitSeq(markdown, "\n") {
 		if !inBlock {
-			if strings.TrimSpace(line) == "```yaml" {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "```yaml" || trimmed == "```yml" {
 				inBlock = true
 				current = nil
 			}
@@ -61,6 +65,9 @@ func yamlBlocks(markdown string) []string {
 			continue
 		}
 		current = append(current, line)
+	}
+	if inBlock {
+		t.Fatal("README contains an unterminated yaml code fence")
 	}
 	return blocks
 }
@@ -84,7 +91,7 @@ func TestREADMEFlagBlockMatchesCLI(t *testing.T) {
 // one place has to be made in the other.
 func TestREADMESchemaMatchesHelp(t *testing.T) {
 	want := helpSchema(t)
-	for _, block := range yamlBlocks(readREADME(t)) {
+	for _, block := range yamlBlocks(t, readREADME(t)) {
 		if strings.TrimSpace(block) == want {
 			return
 		}
@@ -97,7 +104,7 @@ func TestREADMESchemaMatchesHelp(t *testing.T) {
 func TestREADMEExampleConfigsParse(t *testing.T) {
 	schema := helpSchema(t)
 	examples := 0
-	for index, block := range yamlBlocks(readREADME(t)) {
+	for index, block := range yamlBlocks(t, readREADME(t)) {
 		// The schema block describes field types rather than values.
 		if strings.TrimSpace(block) == schema {
 			continue
@@ -118,5 +125,35 @@ func TestREADMEExampleConfigsParse(t *testing.T) {
 	}
 	if examples == 0 {
 		t.Fatal("found no README example configs to validate")
+	}
+}
+
+// The GitHub Action examples pin the released version, which on main is the
+// version in cmd/root.go, so a release bump that skips the README fails here.
+func TestREADMEActionExamplesPinCurrentVersion(t *testing.T) {
+	pins := 0
+	for index, block := range yamlBlocks(t, readREADME(t)) {
+		if !strings.Contains(block, `uses: "aquia-inc/emberfall`) {
+			continue
+		}
+		found := false
+		for line := range strings.SplitSeq(block, "\n") {
+			trimmed := strings.TrimSpace(line)
+			version, ok := strings.CutPrefix(trimmed, "version: ")
+			if !ok {
+				continue
+			}
+			found = true
+			pins++
+			if version != rootCmd.Version {
+				t.Errorf("README action example %d pins version %s; the binary is %s", index, version, rootCmd.Version)
+			}
+		}
+		if !found {
+			t.Errorf("README action example %d has no version pin:\n%s", index, block)
+		}
+	}
+	if pins == 0 {
+		t.Fatal("found no README action examples to validate")
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,11 @@ tests:
     text: string # to send as content-type text/plain
     json: object # to send as content-type application/json
       # arbitrary key:value pairs
+    multipart: object # to send as content-type multipart/form-data
+      fields: object # optional, key:value form fields
+      files: object # optional, form-field-name:local-file-path
+        # paths are resolved relative to the working directory; per-file
+        # Content-Type is derived from the file extension
   expect:
     status: int # a supported HTTP status code such as 200,201,301,400,404, etc...
     body: object # optional

--- a/internal/engine/multipart.go
+++ b/internal/engine/multipart.go
@@ -23,9 +23,10 @@ const maxMultipartFileSize = 50 * 1024 * 1024 // 50 MiB
 // quoteEscaper mirrors the stdlib's mime/multipart.escapeQuotes (which is
 // unexported) so that field and filename values are quoted the same way
 // CreateFormFile would do it. Non-ASCII bytes are passed through as raw UTF-8,
-// which lenient servers parse correctly. Strict RFC 5987 (filename*=UTF-8''...)
-// encoding is not implemented; non-ASCII filenames may not interoperate with
-// servers that reject anything outside the legacy quoted-string form.
+// which lenient servers parse correctly. Strict RFC 5987 encoding
+// (filename*=charset'lang'value) is not implemented; non-ASCII filenames may
+// not interoperate with servers that reject anything outside the legacy
+// quoted-string form.
 var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
 
 // writeMultipart writes a multipart/form-data payload into buf and returns the


### PR DESCRIPTION
Closes #65. The README's CLI Usage block and examples are synced against the shipped binary, and a set of Go tests now holds them there.

Four defects, all reproducible against v0.5.0: the tests flag was documented as `-c` but registered as `-t`, so the first command a new user copies fails with `unknown shorthand flag`; `-m, --method` (added in #43) was absent from the flag list; both `expect.body` examples passed a scalar where the engine requires an object, aborting with a YAML unmarshal error before any request ran; and the GitHub Action examples pinned 0.4.0. A fifth instance of the same drift turned up during the fix: the schema embedded in `cmd/root.go`'s `--help` text was missing the `multipart` block from #51.

The fix is a docs pass plus a guard, because the docs and the binary had no mechanical connection - nothing failed when they diverged, so they diverged. `cmd/docs_test.go` adds four checks: the README flag block must contain cobra's rendered `FlagUsages()` verbatim, the README schema block must match the one `--help` prints, every README example config must unmarshal into `engine.Config`, and the action examples must pin the version in `cmd/root.go` (which on main is always the latest release). Generating the README from cobra was the heavier alternative and lost: a checked-in block that CI compares is simpler and keeps the README hand-editable.

One consequence: this repo's CI never ran `go test` (tests.yaml compiles and runs bats only), so the guards could not have failed a PR. tests.yaml gains a `go test ./...` step. That is the change worth a reviewer's scrutiny - it means any future failing Go test blocks PRs, which is a behavior change for the pipeline, and it will conflict trivially with #64's tests.yaml rewrite (whichever lands second re-adds one step).

Rider: `internal/engine/multipart.go` gets a comment-only reword. gofmt's doc-comment canonicalizer rewrites the doubled apostrophe in `filename*=UTF-8''...` into a typographic quote, corrupting the RFC 5987 syntax the comment documents, and the file failed `gofmt -l`. Describing the general `charset'lang'value` form instead makes the file a gofmt fixed point. No behavior change. This matters before #64 lands, since #64 adds a `gofmt -w` pre-commit hook that would have mangled the comment on first contact.

Testing: each of the four original defects was reintroduced one at a time and the corresponding test confirmed to fail; the issue's verbatim reproduction now parses and proceeds to the HTTP request; `go vet`, `staticcheck` (2026.1), and `gofmt -l` are clean; the full suite passes. Not needed: no engine or CLI behavior changes, so the bats suite and action.yml are untouched.
